### PR TITLE
fix issue #24

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Before using you must first connect all devices to MAX! Cube via MAX! Firmware.
 ## Changelog
 
 ### 1.0.3 (2021-04-10)
-* (Apollon77) fixed state has no existing object for info.serial_number
+* (thost96) fixed state has no existing object for info.serial_number
 
 ### 1.0.2 (2020-07-28)
 * (Apollon77) Update dependencies

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Before using you must first connect all devices to MAX! Cube via MAX! Firmware.
 
 ## Changelog
 
+### 1.0.3 (2021-04-10)
+* (Apollon77) fixed state has no existing object for info.serial_number
+
 ### 1.0.2 (2020-07-28)
 * (Apollon77) Update dependencies
 * (Apollon77) make compatible with js-controller 3

--- a/io-package.json
+++ b/io-package.json
@@ -156,10 +156,10 @@
             "native": {}
         },
         {
-            "_id": "info.serial",
+            "_id": "info.serial_number",
             "type": "state",
             "common": {
-                "role":  "info.serial",
+                "role":  "info.serial_number",
                 "name": "Serial number",
                 "type": "string",
                 "read": true,


### PR DESCRIPTION
Hi,

as the adapter sets info.serial_number in main.js [L757](https://github.com/ioBroker/ioBroker.maxcube/blob/c6ec52643c7d841ada99ce2f9e59b0c0d945a7a6/main.js#L757) and only info.serial was defined before, i added a short fix in this PR to get this simple issue fixed. 